### PR TITLE
Handle optional ws deps in Vercel build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,16 @@
 /** @type {import('next').NextConfig} */
+const nodeExternals = require('webpack-node-externals');
+
 const nextConfig = {
   output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },
   images: { unoptimized: true },
+  webpack: (config, { isServer }) => {
+    if (isServer) config.externals.push(nodeExternals());
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,9 @@
         "typescript": "5.2.2",
         "vaul": "^0.9.9",
         "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "webpack-node-externals": "^3.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6981,6 +6984,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/webpack-node-externals": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
+      "integrity": "sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "typescript": "5.2.2",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "webpack-node-externals": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `webpack-node-externals` to dev dependencies
- exclude optional ws packages in Next.js webpack config

## Testing
- `npm run build` *(fails: Failed to collect page data for /profile)*

------
https://chatgpt.com/codex/tasks/task_e_6849b1249920832ab3b501565630f757