### PR TITLE
Add token distribution and analytics features

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { supabase } from "@/lib/supabase";
+import { User } from "@supabase/supabase-js";
+
+interface Stats { tokens: number; badges: string[]; totalImages: number; }
+
+export default function AnalyticsPage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!user) {
+        router.push('/login');
+        return;
+      }
+      setUser(user);
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/creator-stats/${user.id}`)
+        .then(res => res.json())
+        .then(setStats)
+        .catch(() => {});
+    });
+  }, [router]);
+
+  if (!user || !stats) return null;
+
+  return (
+    <div className="container mx-auto py-10">
+      <Card className="max-w-2xl mx-auto">
+        <CardHeader>
+          <CardTitle>Your Stats</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>Total Images: {stats.totalImages}</p>
+          <p>Total Tokens: {stats.tokens}</p>
+          <p>Badges: {stats.badges.join(', ') || 'None'}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { supabase } from "@/lib/supabase";
+
+interface Entry { id: string; name: string; tokens: number; }
+
+export default function LeaderboardPage() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/leaderboard`)
+      .then(res => res.json())
+      .then(setEntries)
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="container mx-auto py-10">
+      <Card className="max-w-2xl mx-auto">
+        <CardHeader>
+          <CardTitle>Leaderboard</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ol className="space-y-2">
+            {entries.map((e, i) => (
+              <li key={e.id} className="flex justify-between">
+                <span>{i + 1}. {e.name || e.id}</span>
+                <span>{e.tokens} tokens</span>
+              </li>
+            ))}
+          </ol>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/backend/src/models/Image.js
+++ b/backend/src/models/Image.js
@@ -4,6 +4,7 @@ const imageSchema = new mongoose.Schema({
   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
   ev: Number,
   storagePath: String,
+  tokens: Number,
 }, { timestamps: true });
 
 export default mongoose.model('Image', imageSchema);

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -3,6 +3,8 @@ import mongoose from 'mongoose';
 const userSchema = new mongoose.Schema({
   email: { type: String, required: true, unique: true },
   name: String,
+  tokens: { type: Number, default: 0 },
+  badges: { type: [String], default: [] },
 }, { timestamps: true });
 
 export default mongoose.model('User', userSchema);

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -2,6 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import { Storage } from 'firebase-admin/storage';
 import Image from '../models/Image.js';
+import User from '../models/User.js';
 import { extractEV } from '../utils/ev.js';
 import { rewardTokens } from '../utils/token.js';
 
@@ -15,11 +16,24 @@ router.post('/upload-image', upload.single('file'), async (req, res) => {
     await file.save(req.file.buffer, { contentType: req.file.mimetype });
 
     const ev = extractEV(req.file.buffer);
+    const position = await Image.countDocuments() + 1;
+    const tokens = rewardTokens(ev, position);
     const image = await Image.create({
       userId: req.body.userId,
       ev,
       storagePath: file.name,
+      tokens,
     });
+
+    const user = await User.findById(req.body.userId);
+    if (user) {
+      user.tokens += tokens;
+      if (user.tokens >= 100 && !user.badges.includes('Contributor')) {
+        user.badges.push('Contributor');
+      }
+      await user.save();
+    }
+
     res.json(image);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import User from '../models/User.js';
+import Image from '../models/Image.js';
 
 const router = express.Router();
 
@@ -18,6 +19,28 @@ router.get('/user/:id', async (req, res) => {
     res.json(user);
   } catch (err) {
     res.status(404).json({ error: 'User not found' });
+  }
+});
+
+router.get('/leaderboard', async (_req, res) => {
+  const users = await User.find().sort({ tokens: -1 }).limit(10);
+  res.json(users.map(u => ({ id: u._id, name: u.name, tokens: u.tokens })));
+});
+
+router.get('/creator-stats/:id', async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    const totalImages = await Image.countDocuments({ userId: req.params.id });
+    res.json({
+      id: user._id,
+      name: user.name,
+      tokens: user.tokens,
+      badges: user.badges,
+      totalImages,
+    });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
   }
 });
 

--- a/backend/src/utils/token.js
+++ b/backend/src/utils/token.js
@@ -1,4 +1,6 @@
-export function rewardTokens(ev, weights = []) {
-  const avg = weights.length ? weights.reduce((a, b) => a + b, 0) / weights.length : 1;
-  return Math.round(ev * avg);
+export function rewardTokens(ev, position = 1, supplyWeight = 1) {
+  const max = 10;
+  const k = 0.1;
+  const logistic = 1 / (1 + Math.exp(-k * (position - 50)));
+  return Math.round(ev * logistic * supplyWeight * max);
 }

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -26,6 +26,12 @@ export function SiteHeader() {
             <Link href="/about" className="text-sm font-medium transition-colors hover:text-primary">
               About
             </Link>
+            <Link href="/leaderboard" className="text-sm font-medium transition-colors hover:text-primary">
+              Leaderboard
+            </Link>
+            <Link href="/analytics" className="text-sm font-medium transition-colors hover:text-primary">
+              Analytics
+            </Link>
           </nav>
           <div className="flex items-center space-x-4">
             <Button variant="ghost" asChild>

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -33,7 +33,31 @@ Upload a JPEG file and store metadata.
 {
   "_id": "<mongoId>",
   "ev": 8.5,
-  "storagePath": "<firebase path>"
+    "storagePath": "<firebase path>"
+  }
+```
+
+## GET `/leaderboard`
+Return top users by tokens.
+
+### Response
+```json
+[
+  { "id": "1", "name": "Jane", "tokens": 123 }
+]
+```
+
+## GET `/creator-stats/:id`
+Return image and token stats for a user.
+
+### Response
+```json
+{
+  "id": "1",
+  "name": "Jane",
+  "tokens": 123,
+  "badges": ["Contributor"],
+  "totalImages": 5
 }
 ```
 


### PR DESCRIPTION
## Summary
- reward token distribution using logistic formula
- store token count and badges on users and images
- update image upload route to allocate tokens and contributor badge
- expose leaderboard and creator stats APIs
- document new endpoints
- show leaderboard and analytics pages
- link new pages from the site header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849b503e7a0832a84cc6674fb35dde5