### PR TITLE
Add NEXT_PUBLIC_API_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ MONGODB_URI=
 
 # API
 API_URL=http://localhost:4000/api
+NEXT_PUBLIC_API_URL=http://localhost:4000/api
 
 # Next.js client
 NEXT_PUBLIC_SUPABASE_URL=

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install
 npm run dev
 ```
 
-3. Copy `.env.example` to `.env` and fill in the values for Firebase and MongoDB.
+3. Copy `.env.example` to `.env` and fill in the values for Firebase and MongoDB. Set both `API_URL` and `NEXT_PUBLIC_API_URL` to the backend URL so the frontend can reach the API.
 
 4. Run the Next.js development server:
 


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_API_URL` to `.env.example`
- document the new env variable in the setup instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ba169f4c832abcdf2fa62ba1b245