### PR TITLE
Add placeholder pages for site navigation

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <div className="container py-10">
+      <h1 className="text-2xl font-bold">About Arkaiv</h1>
+      <p className="text-muted-foreground">More details about the project will appear here.</p>
+    </div>
+  );
+}

--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,0 +1,8 @@
+export default function BrowsePage() {
+  return (
+    <div className="container py-10">
+      <h1 className="text-2xl font-bold">Browse Repositories</h1>
+      <p className="text-muted-foreground">Coming soon...</p>
+    </div>
+  );
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,8 @@
+export default function PricingPage() {
+  return (
+    <div className="container py-10">
+      <h1 className="text-2xl font-bold">Pricing</h1>
+      <p className="text-muted-foreground">Information on plans will be here soon.</p>
+    </div>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,8 @@
+export default function SignupPage() {
+  return (
+    <div className="container py-10">
+      <h1 className="text-2xl font-bold">Create an Account</h1>
+      <p className="text-muted-foreground">Signup functionality coming soon.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder pages for Browse, Pricing, About and Signup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ba0c314c832aa6b5b0919b114553