### PR TITLE
Add signup page

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from 'next/navigation';
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { UserPlus } from "lucide-react";
+import { supabase } from '@/lib/supabase';
+import { useToast } from "@/hooks/use-toast";
+
+export default function SignUpPage() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const handleSignUp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    try {
+      const { data, error } = await supabase.auth.signUp({ email, password });
+      if (error || !data.user) throw error || new Error('No user returned');
+
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
+      const res = await fetch(`${apiUrl}/register-user`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: data.user.id, email, name })
+      });
+
+      if (!res.ok) throw new Error('Failed to register user');
+
+      toast({
+        title: "Success",
+        description: "Your account has been created.",
+      });
+      router.push('/profile');
+    } catch (err) {
+      toast({
+        title: "Error",
+        description: "Failed to sign up. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-1">
+          <div className="flex items-center justify-center mb-4">
+            <UserPlus className="h-10 w-10 text-primary" />
+          </div>
+          <CardTitle className="text-2xl text-center font-bold">Create an account</CardTitle>
+          <CardDescription className="text-center">
+            Sign up to start uploading images
+          </CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSignUp}>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col space-y-4">
+            <Button className="w-full" type="submit" disabled={isLoading}>
+              {isLoading ? "Signing up..." : "Create Account"}
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a signup page that uses `supabase.auth.signUp`
- register the signed up user in MongoDB via `/register-user`
- redirect to `/profile` after a successful signup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ba19b9e0832ab2cc33ef6cc827a9