### PR TITLE
Add browse feed page

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { SiteHeader } from "@/components/site-header";
+
+interface ImageItem {
+  _id: string;
+  storagePath: string;
+}
+
+export default function BrowsePage() {
+  const [images, setImages] = useState<ImageItem[]>([]);
+
+  useEffect(() => {
+    async function fetchFeed() {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/feed`);
+        if (!res.ok) {
+          console.error("Failed to fetch feed");
+          return;
+        }
+        const data = await res.json();
+        setImages(data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    fetchFeed();
+  }, []);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
+      <main className="container flex-1 py-10">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+          {images.map((img) => (
+            <Link href={`/images/${img._id}`} key={img._id} className="block">
+              <img
+                src={img.storagePath}
+                alt="Image thumbnail"
+                className="aspect-square w-full rounded-md object-cover border"
+              />
+            </Link>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `app/browse/page.tsx` to display images from the `/feed` endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849ba215f28832ab89d69bde30c107b