### PR TITLE
Add session hook and improve API error handling

### DIFF
--- a/hooks/use-session.ts
+++ b/hooks/use-session.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabase';
+import { User } from '@supabase/supabase-js';
+
+export function useSession() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const { data, error } = await supabase.auth.getUser();
+      if (error || !data.user) {
+        router.push('/login');
+        setLoading(false);
+        return;
+      }
+      setUser(data.user);
+      setLoading(false);
+    };
+
+    checkSession();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!session?.user) {
+        router.push('/login');
+        setUser(null);
+      } else {
+        setUser(session.user);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [router]);
+
+  return { user, loading };
+}


### PR DESCRIPTION
## Summary
- centralize Supabase auth logic in new `useSession` hook
- use the hook in the profile page
- fetch user details with error handling for API failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ba242c80832abfd6376658d3a8b7