### PR TITLE
Add supabaseId to user model and update routes

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 
 const userSchema = new mongoose.Schema({
   email: { type: String, required: true, unique: true },
+  supabaseId: { type: String, unique: true },
   name: String,
 }, { timestamps: true });
 

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,11 +1,13 @@
 import express from 'express';
 import User from '../models/User.js';
+import TokenLedger from '../models/TokenLedger.js';
 
 const router = express.Router();
 
 router.post('/register-user', async (req, res) => {
   try {
-    const user = await User.create(req.body);
+    const { email, name, supabaseId } = req.body;
+    const user = await User.create({ email, name, supabaseId });
     res.json(user);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -14,10 +16,27 @@ router.post('/register-user', async (req, res) => {
 
 router.get('/user/:id', async (req, res) => {
   try {
-    const user = await User.findById(req.params.id);
+    const user = await User.findOne({ supabaseId: req.params.id });
+    if (!user) throw new Error('User not found');
     res.json(user);
   } catch (err) {
     res.status(404).json({ error: 'User not found' });
+  }
+});
+
+router.get('/creator-stats/:id', async (req, res) => {
+  try {
+    const user = await User.findOne({ supabaseId: req.params.id });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    const result = await TokenLedger.aggregate([
+      { $match: { userId: user._id } },
+      { $group: { _id: '$userId', tokens: { $sum: '$tokens' } } },
+    ]);
+
+    res.json({ supabaseId: user.supabaseId, totalTokens: result[0]?.tokens || 0 });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- add `supabaseId` field to `User` schema
- record `supabaseId` on `/register-user`
- look up users by `supabaseId` and add `/creator-stats/:id`

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6849ba1c6648832ab5d76f4bfe8a1ed0