### PR TITLE
Fix signup payload

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -30,7 +30,7 @@ export default function SignUpPage() {
       const res = await fetch(`${apiUrl}/register-user`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: data.user.id, email, name })
+        body: JSON.stringify({ supabaseId: data.user.id, email, name })
       });
 
       if (!res.ok) throw new Error('Failed to register user');


### PR DESCRIPTION
## Summary
- send `supabaseId` instead of `id` when registering a new user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b0bf1bbdc832a9f5459c378efc535