### PR TITLE
Support all image types

### DIFF
--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -106,7 +106,7 @@ export default function UploadPage() {
                 className="hidden"
                 id="file-upload"
                 multiple
-                accept="image/*,.pdf,.doc,.docx"
+                accept="image/*"
                 onChange={handleFileSelect}
               />
               <label

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -8,9 +8,16 @@ import { authenticate } from '../middleware/auth.js';
 
 const router = express.Router();
 const upload = multer({ storage: multer.memoryStorage() });
+const SUPPORTED_MIME_REGEX = /^image\//;
 
 router.post('/upload-image', authenticate, upload.single('file'), async (req, res) => {
   try {
+    if (!req.file) {
+      throw new Error('No file uploaded');
+    }
+    if (!SUPPORTED_MIME_REGEX.test(req.file.mimetype)) {
+      return res.status(400).json({ error: 'Unsupported MIME type' });
+    }
     const bucket = new Storage().bucket();
     const file = bucket.file(Date.now() + '-' + req.file.originalname);
     await file.save(req.file.buffer, { contentType: req.file.mimetype });

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -23,11 +23,12 @@ Create a new user.
 ```
 
 ## POST `/upload-image`
-Upload a JPEG file and store metadata. This endpoint requires an
+Upload an image file and store metadata. This endpoint requires an
 `Authorization: Bearer <token>` header containing a valid Supabase session
 token.
 
 - `file` – multipart form field
+- Supported formats: JPEG, PNG, GIF, TIFF, WebP, HEIF/HEIC, AVIF and common camera RAW files such as DNG, NEF, CR2/CR3, ARW, ORF, RW2 and RAF.
 
 ### Response
 ```json


### PR DESCRIPTION
## Summary
- document supported MIME types for `/upload-image`
- validate uploads to reject unsupported MIME types
- narrow the Upload page file input to accept only image formats

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b0d40708c832a8c3fd79c702b0a8c