### PR TITLE
Add wallet page with token balance

### DIFF
--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { useSession } from '@/hooks/use-session';
+import { useToast } from '@/hooks/use-toast';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+
+interface Transaction {
+  _id: string;
+  imageId: string;
+  tokens: number;
+  createdAt: string;
+}
+
+interface Stats {
+  totalTokens: number;
+  transactions: Transaction[];
+}
+
+export default function WalletPage() {
+  const { user, loading } = useSession();
+  const { toast } = useToast();
+  const [stats, setStats] = useState<Stats | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    const fetchStats = async () => {
+      try {
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
+        const res = await fetch(`${apiUrl}/creator-stats/${user.id}`);
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        setStats(data);
+      } catch (err) {
+        toast({
+          title: 'Error',
+          description: 'Failed to load wallet data.',
+          variant: 'destructive',
+        });
+      }
+    };
+    fetchStats();
+  }, [user, toast]);
+
+  if (loading || !user) return null;
+
+  return (
+    <div className="container mx-auto py-10">
+      <Card className="max-w-2xl mx-auto">
+        <CardHeader>
+          <CardTitle>Wallet</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div>
+            <h3 className="font-medium">Total Tokens</h3>
+            <p className="text-gray-600">{stats?.totalTokens ?? 0}</p>
+          </div>
+          <div>
+            <h3 className="mb-2 font-medium">Recent Transactions</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Tokens</TableHead>
+                  <TableHead>Image ID</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {stats?.transactions?.map((tx) => (
+                  <TableRow key={tx._id}>
+                    <TableCell>{new Date(tx.createdAt).toLocaleString()}</TableCell>
+                    <TableCell>{tx.tokens}</TableCell>
+                    <TableCell>{tx.imageId}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -34,7 +34,15 @@ router.get('/creator-stats/:id', async (req, res) => {
       { $group: { _id: '$userId', tokens: { $sum: '$tokens' } } },
     ]);
 
-    res.json({ supabaseId: user.supabaseId, totalTokens: result[0]?.tokens || 0 });
+    const transactions = await TokenLedger.find({ userId: user._id })
+      .sort({ createdAt: -1 })
+      .limit(10);
+
+    res.json({
+      supabaseId: user.supabaseId,
+      totalTokens: result[0]?.tokens || 0,
+      transactions,
+    });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -26,6 +26,9 @@ export function SiteHeader() {
             <Link href="/about" className="text-sm font-medium transition-colors hover:text-primary">
               About
             </Link>
+            <Link href="/wallet" className="text-sm font-medium transition-colors hover:text-primary">
+              Wallet
+            </Link>
           </nav>
           <div className="flex items-center space-x-4">
             <Button variant="ghost" asChild>


### PR DESCRIPTION
## Summary
- extend `/creator-stats/:id` to return recent TokenLedger records
- add `/wallet` page to show token balance and recent transactions
- link to Wallet page from the site header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0d43863c832aac7bf617b96fe6fc