### PR TITLE
Fix sign-up registration body parameter

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -30,7 +30,7 @@ export default function SignUpPage() {
       const res = await fetch(`${apiUrl}/register-user`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: data.user.id, email, name })
+        body: JSON.stringify({ supabaseId: data.user.id, email, name })
       });
 
       if (!res.ok) throw new Error('Failed to register user');


### PR DESCRIPTION
## Summary
- use `supabaseId` when registering a new user after sign-up

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b0e12452c832a8383ca06db36277c