### PR TITLE
Use internal user id for image uploads

### DIFF
--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -55,7 +55,6 @@ export default function UploadPage() {
       for (const { file } of selectedFiles) {
         const formData = new FormData();
         formData.append('file', file);
-        formData.append('userId', user.id);
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/upload-image`, {
           method: 'POST',
           body: formData,

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -2,6 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import { Storage } from 'firebase-admin/storage';
 import Image from '../models/Image.js';
+import User from '../models/User.js';
 import { extractEV } from '../utils/ev.js';
 import { rewardTokens } from '../utils/token.js';
 import { authenticate } from '../middleware/auth.js';
@@ -16,8 +17,14 @@ router.post('/upload-image', authenticate, upload.single('file'), async (req, re
     await file.save(req.file.buffer, { contentType: req.file.mimetype });
 
     const ev = extractEV(req.file.buffer);
+
+    const user = await User.findOne({ supabaseId: req.user.id });
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
     const image = await Image.create({
-      userId: req.user?.id || req.body.userId,
+      userId: user._id,
       ev,
       storagePath: file.name,
     });


### PR DESCRIPTION
## Summary
- look up Mongo user via `supabaseId` in the upload route
- store the user's Mongo `_id` when creating images
- stop sending `userId` from the upload page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0e12f4b8832a9fa93cf6d7c8d8e1