### PR TITLE
Add token ledger on image upload

### DIFF
--- a/backend/__tests__/images.test.ts
+++ b/backend/__tests__/images.test.ts
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+jest.unstable_mockModule('../src/models/Image.js', () => ({ default: { create: jest.fn() } }));
+jest.unstable_mockModule('../src/models/TokenLedger.js', () => ({ default: { create: jest.fn() } }));
+jest.unstable_mockModule('firebase-admin/storage', () => ({
+  Storage: jest.fn().mockImplementation(() => ({
+    bucket: jest.fn().mockReturnValue({
+      file: jest.fn().mockReturnValue({
+        save: jest.fn().mockResolvedValue(undefined)
+      })
+    })
+  }))
+}));
+jest.unstable_mockModule('../src/utils/ev.js', () => ({
+  extractEV: jest.fn(() => 1)
+}));
+
+let handler: any;
+let Image: any;
+let TokenLedger: any;
+beforeAll(async () => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'key';
+  const mod = await import('../src/routes/images.js');
+  const router = mod.default;
+  Image = (await import('../src/models/Image.js')).default;
+  TokenLedger = (await import('../src/models/TokenLedger.js')).default;
+  const layer = (router as any).stack.find((l: any) => l.route && l.route.path === '/upload-image');
+  handler = layer.route.stack[2].handle;
+});
+
+describe('upload-image', () => {
+  test('creates ledger entry', async () => {
+    (Image.create as jest.Mock).mockResolvedValue({ _id: 'img1', userId: 'user1', ev: 1, storagePath: 'path' });
+    const req: any = { file: { buffer: Buffer.from('data'), originalname: 'a.jpg', mimetype: 'image/jpeg' }, user: { id: 'user1' }, body: {} };
+    const res: any = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+    await handler(req, res);
+    const expectedTokens = 1;
+    expect(TokenLedger.create).toHaveBeenCalledWith({ userId: 'user1', imageId: 'img1', tokens: expectedTokens });
+    expect(res.json).toHaveBeenCalledWith({ image: { _id: 'img1', userId: 'user1', ev: 1, storagePath: 'path' }, tokens: expectedTokens });
+  });
+});

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -2,6 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import { Storage } from 'firebase-admin/storage';
 import Image from '../models/Image.js';
+import TokenLedger from '../models/TokenLedger.js';
 import { extractEV } from '../utils/ev.js';
 import { rewardTokens } from '../utils/token.js';
 import { authenticate } from '../middleware/auth.js';
@@ -16,12 +17,21 @@ router.post('/upload-image', authenticate, upload.single('file'), async (req, re
     await file.save(req.file.buffer, { contentType: req.file.mimetype });
 
     const ev = extractEV(req.file.buffer);
+    const tokens = rewardTokens(ev);
+    const userId = req.user?.id || req.body.userId;
     const image = await Image.create({
-      userId: req.user?.id || req.body.userId,
+      userId,
       ev,
       storagePath: file.name,
     });
-    res.json(image);
+
+    await TokenLedger.create({
+      userId,
+      imageId: image._id,
+      tokens,
+    });
+
+    res.json({ image, tokens });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,10 @@
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.ts?(x)']
+  testMatch: ['**/__tests__/**/*.ts?(x)'],
+  globals: {
+    'ts-jest': {
+      useESM: true
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- award tokens when uploading images
- expose awarded tokens in response
- run Jest in ESM mode
- cover token ledger creation with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0d3e422c832aa3709ad529b462cb