### PR TITLE
Update upload-image to use User _id

### DIFF
--- a/backend/__tests__/images.test.ts
+++ b/backend/__tests__/images.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 jest.unstable_mockModule('../src/models/Image.js', () => ({ default: { create: jest.fn() } }));
 jest.unstable_mockModule('../src/models/TokenLedger.js', () => ({ default: { create: jest.fn() } }));
+jest.unstable_mockModule('../src/models/User.js', () => ({ default: { findOne: jest.fn() } }));
 jest.unstable_mockModule('firebase-admin/storage', () => ({
   Storage: jest.fn().mockImplementation(() => ({
     bucket: jest.fn().mockReturnValue({
@@ -17,6 +18,7 @@ jest.unstable_mockModule('../src/utils/ev.js', () => ({
 let handler: any;
 let Image: any;
 let TokenLedger: any;
+let User: any;
 beforeAll(async () => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'key';
@@ -24,18 +26,20 @@ beforeAll(async () => {
   const router = mod.default;
   Image = (await import('../src/models/Image.js')).default;
   TokenLedger = (await import('../src/models/TokenLedger.js')).default;
+  User = (await import('../src/models/User.js')).default;
   const layer = (router as any).stack.find((l: any) => l.route && l.route.path === '/upload-image');
   handler = layer.route.stack[2].handle;
 });
 
 describe('upload-image', () => {
   test('creates ledger entry', async () => {
-    (Image.create as jest.Mock).mockResolvedValue({ _id: 'img1', userId: 'user1', ev: 1, storagePath: 'path' });
+    (Image.create as jest.Mock).mockResolvedValue({ _id: 'img1', userId: 'mongo1', ev: 1, storagePath: 'path' });
+    (User.findOne as jest.Mock).mockResolvedValue({ _id: 'mongo1', supabaseId: 'user1' });
     const req: any = { file: { buffer: Buffer.from('data'), originalname: 'a.jpg', mimetype: 'image/jpeg' }, user: { id: 'user1' }, body: {} };
     const res: any = { json: jest.fn(), status: jest.fn().mockReturnThis() };
     await handler(req, res);
     const expectedTokens = 1;
-    expect(TokenLedger.create).toHaveBeenCalledWith({ userId: 'user1', imageId: 'img1', tokens: expectedTokens });
-    expect(res.json).toHaveBeenCalledWith({ image: { _id: 'img1', userId: 'user1', ev: 1, storagePath: 'path' }, tokens: expectedTokens });
+    expect(TokenLedger.create).toHaveBeenCalledWith({ userId: 'mongo1', imageId: 'img1', tokens: expectedTokens });
+    expect(res.json).toHaveBeenCalledWith({ image: { _id: 'img1', userId: 'mongo1', ev: 1, storagePath: 'path' }, tokens: expectedTokens });
   });
 });

--- a/backend/src/routes/images.js
+++ b/backend/src/routes/images.js
@@ -3,6 +3,7 @@ import multer from 'multer';
 import { Storage } from 'firebase-admin/storage';
 import Image from '../models/Image.js';
 import TokenLedger from '../models/TokenLedger.js';
+import User from '../models/User.js';
 import { extractEV } from '../utils/ev.js';
 import { authenticate } from '../middleware/auth.js';
 
@@ -28,7 +29,13 @@ router.post('/upload-image', authenticate, upload.single('file'), async (req, re
 
     const ev = extractEV(req.file.buffer);
     const tokens = rewardTokens(ev);
-    const userId = req.user?.id || req.body.userId;
+
+    const userDoc = await User.findOne({ supabaseId: req.user.id });
+    if (!userDoc) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    const userId = userDoc._id;
+
     const image = await Image.create({
       userId,
       ev,


### PR DESCRIPTION
## Summary
- use User model to resolve the auth user by `supabaseId` in the upload route
- save Image and TokenLedger entries with this MongoDB `_id`
- adjust tests for new behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b191fe298832ab818f3ed40cd4be9