### PR TITLE
Add History component

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { SiteHeader } from "@/components/site-header";
+import { History } from "@/components/history";
 
 interface ImageItem {
   _id: string;
@@ -35,17 +35,7 @@ export default function BrowsePage() {
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
       <main className="container flex-1 py-10">
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
-          {images.map((img) => (
-            <Link href={`/images/${img._id}`} key={img._id} className="block">
-              <img
-                src={img.publicUrl}
-                alt="Image thumbnail"
-                className="aspect-square w-full rounded-md object-cover border"
-              />
-            </Link>
-          ))}
-        </div>
+        <History archives={images} />
       </main>
     </div>
   );

--- a/components/history.tsx
+++ b/components/history.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+interface ArchiveItem {
+  _id: string;
+  storagePath: string;
+  publicUrl: string;
+}
+
+interface HistoryProps {
+  archives: ArchiveItem[];
+}
+
+export function History({ archives }: HistoryProps) {
+  if (!archives || archives.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No archived items found.</p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+      {archives.map((item) => (
+        <Link href={`/images/${item._id}`} key={item._id} className="block">
+          <img
+            src={item.publicUrl}
+            alt="Archived item"
+            className="aspect-square w-full rounded-md object-cover border"
+          />
+        </Link>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a `History` component to show archived items
- use the new component in the browse page

## Testing
- `npm test` *(fails: Cannot find module 'firebase-admin/storage')*

------
https://chatgpt.com/codex/tasks/task_e_684c1796df68832a925a9b19ef999ba3