### PR TITLE
Add archive history endpoint

### DIFF
--- a/backend/__tests__/archive.test.ts
+++ b/backend/__tests__/archive.test.ts
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+jest.unstable_mockModule('../src/models/User.js', () => ({ default: { findOne: jest.fn() } }));
+
+let handler: any;
+let User: any;
+
+beforeAll(async () => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'key';
+  const mod = await import('../src/routes/users.js');
+  const router = mod.default;
+  User = (await import('../src/models/User.js')).default;
+  const layer = (router as any).stack.find((l: any) => l.route && l.route.path === '/archive');
+  handler = layer.route.stack[1].handle;
+});
+
+describe('archive', () => {
+  test('adds entry to user history', async () => {
+    const save = jest.fn();
+    const userDoc = { _id: 'mongo1', supabaseId: 'user1', history: [], save };
+    (User.findOne as jest.Mock).mockResolvedValue(userDoc);
+    const req: any = { body: { text: 'hello' }, user: { id: 'user1' } };
+    const res: any = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+    await handler(req, res);
+    expect(userDoc.history[0].text).toBe('hello');
+    expect(save).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ text: 'hello' }));
+  });
+});

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -5,6 +5,13 @@ const userSchema = new mongoose.Schema(
     supabaseId: { type: String, required: true, unique: true },
     email: { type: String, required: true },
     name: { type: String },
+    history: [
+      {
+        text: String,
+        createdAt: { type: Date, default: Date.now },
+        imageId: { type: mongoose.Schema.Types.ObjectId, ref: 'Image' },
+      },
+    ],
   },
   { timestamps: true }
 );

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -49,3 +49,22 @@ Return recent images.
   { "_id": "1", "ev": 10.2, "storagePath": "...", "publicUrl": "..." }
 ]
 ```
+
+## POST `/archive`
+Add a text entry to the authenticated user's history. Requires an
+`Authorization: Bearer <token>` header.
+
+### Request Body
+```json
+{
+  "text": "My note"
+}
+```
+
+### Response
+```json
+{
+  "text": "My note",
+  "createdAt": "2025-01-01T00:00:00.000Z"
+}
+```


### PR DESCRIPTION
## Summary
- add `history` field to user model
- implement `/archive` route that saves entries
- POST to `/archive` from Archive page
- document `/archive` API endpoint
- test archive handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c1c1e8f94832aa5ad31fc525f294d