### PR TITLE
Add loading skeleton on browse feed

### DIFF
--- a/app/browse/page.tsx
+++ b/app/browse/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { SiteHeader } from "@/components/site-header";
 import { History } from "@/components/history";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface ImageItem {
   _id: string;
@@ -12,9 +13,11 @@ interface ImageItem {
 
 export default function BrowsePage() {
   const [images, setImages] = useState<ImageItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     async function fetchFeed() {
+      setIsLoading(true);
       try {
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/feed`);
         if (!res.ok) {
@@ -25,6 +28,8 @@ export default function BrowsePage() {
         setImages(data);
       } catch (err) {
         console.error(err);
+      } finally {
+        setIsLoading(false);
       }
     }
 
@@ -35,7 +40,15 @@ export default function BrowsePage() {
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
       <main className="container flex-1 py-10">
-        <History archives={images} />
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-square w-full rounded-md" />
+            ))}
+          </div>
+        ) : (
+          <History archives={images} />
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- show skeletons while loading feed data on Browse page

## Testing
- `npm test` *(fails: Cannot find module 'firebase-admin/storage')*


------
https://chatgpt.com/codex/tasks/task_e_684c1c218a24832a85132ad411318da3